### PR TITLE
Updating imagemin version so it work with latest npm versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "grunt-contrib-copy": "^0.8.0",
     "grunt-contrib-cssmin": "^0.12.3",
     "grunt-contrib-htmlmin": "^0.4.0",
-    "grunt-contrib-imagemin": "^0.9.4",
+    "grunt-contrib-imagemin": "^1.0.0",
     "grunt-contrib-jshint": "^0.11.2",
     "grunt-contrib-uglify": "^0.9.1",
     "grunt-contrib-watch": "^0.6.1",


### PR DESCRIPTION
In order to avoid the "Cannot read property 'contents' of undefined" error while running the image min task with npm version 3.3.9 and above we need to use the grunt-contrib-imagemin version 1.0.0
